### PR TITLE
Run OpenRewrite through Maven command and show EqualsAvoidsNull

### DIFF
--- a/Examples/openrewrite/pom.xml
+++ b/Examples/openrewrite/pom.xml
@@ -14,7 +14,7 @@
     <!--
     mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
       -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:LATEST \
-      -DactiveRecipes=org.openrewrite.java.format.AutoFormat,org.openrewrite.java.cleanup.EqualsAvoidsNull,org.openrewrite.java.testing.junit5.JUnit4to5Migration
+      -Drewrite.activeRecipes=org.openrewrite.java.format.AutoFormat,org.openrewrite.java.cleanup.EqualsAvoidsNull,org.openrewrite.java.testing.junit5.JUnit4to5Migration
     -->
 
     <dependencies>

--- a/Examples/openrewrite/pom.xml
+++ b/Examples/openrewrite/pom.xml
@@ -11,6 +11,11 @@
 
     <artifactId>openrewrite</artifactId>
 
+    <!--
+    mvn -U org.openrewrite.maven:rewrite-maven-plugin:run \
+      -Drewrite.recipeArtifactCoordinates=org.openrewrite.recipe:rewrite-testing-frameworks:LATEST \
+      -DactiveRecipes=org.openrewrite.java.format.AutoFormat,org.openrewrite.java.cleanup.EqualsAvoidsNull,org.openrewrite.java.testing.junit5.JUnit4to5Migration
+    -->
 
     <dependencies>
         <dependency>
@@ -21,54 +26,4 @@
         </dependency>
     </dependencies>
 
-    <build>
-        <plugins>
-            <!-- mvn rewrite:run -->
-            <plugin>
-                <groupId>org.openrewrite.maven</groupId>
-                <artifactId>rewrite-maven-plugin</artifactId>
-                <version>4.38.2</version>
-                <configuration>
-                    <activeRecipes>
-                        <recipe>org.openrewrite.java.format.AutoFormat</recipe>
-                        <recipe>org.openrewrite.java.spring.boot2.SpringBoot2JUnit4to5Migration</recipe>
-                    </activeRecipes>
-                </configuration>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.openrewrite.recipe</groupId>
-                        <artifactId>rewrite-spring</artifactId>
-                        <version>4.31.0</version>
-                    </dependency>
-                    <dependency>
-                        <groupId>org.jetbrains.kotlin</groupId>
-                        <artifactId>kotlin-stdlib</artifactId>
-                        <version>1.8.0</version>
-                    </dependency>
-                </dependencies>
-            </plugin>
-            <!-- Needed as OpenRewrite uses JDK internals -->
-            <plugin>
-                <groupId>org.codehaus.mojo</groupId>
-                <artifactId>exec-maven-plugin</artifactId>
-                <version>3.1.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>exec</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                    <executable>mvn</executable>
-                    <arguments>
-                        <argument>rewrite:run</argument>
-                    </arguments>
-                    <environmentVariables>
-                        <MAVEN_OPTS> --add-exports jdk.compiler/com.sun.tools.javac.code=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.comp=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.file=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.jvm=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.main=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.model=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.processing=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.tree=ALL-UNNAMED --add-exports jdk.compiler/com.sun.tools.javac.util=ALL-UNNAMED</MAVEN_OPTS>
-                    </environmentVariables>
-                </configuration>
-            </plugin>
-        </plugins>
-    </build>
 </project>

--- a/Examples/openrewrite/src/main/java/com/example/Main.java
+++ b/Examples/openrewrite/src/main/java/com/example/Main.java
@@ -5,9 +5,8 @@ public class Main {
         System.out.println("Hello world!");
             System.out.println("Crappy formatting");
 
-        String exampleText = "example";
         String nullText = null;
-        if (nullText.equals(exampleText)) {
+        if (nullText.equals("example")) {
             System.out.println("This breaks");
         }
     }

--- a/Examples/openrewrite/src/test/java/com/example/ExampleTest.java
+++ b/Examples/openrewrite/src/test/java/com/example/ExampleTest.java
@@ -1,13 +1,37 @@
 package com.example;
 
+import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
-import static org.junit.Assert.assertEquals;
+import java.io.File;
+import java.io.IOException;
 
 public class ExampleTest {
 
     @Test
     public void simpleTest() {
-        assertEquals(42, 42);
+        Assert.assertEquals(42, 42);
+    }
+
+    @Rule
+    public TemporaryFolder folder = new TemporaryFolder();
+
+    @Test
+    public void temporaryFileTest() throws IOException {
+        File testFile = folder.newFile("test.txt");
+        Assert.assertTrue(testFile.exists());
+    }
+
+    @Test(expected = IOException.class)
+    public void expectedExceptionTest() throws IOException {
+        maybeThrowException(true);
+    }
+
+    private void maybeThrowException(boolean maybe) throws IOException {
+        if (maybe) {
+            throw new IOException();
+        }
     }
 }


### PR DESCRIPTION
With this change you now run three recipes; a formatter, a small fix and JUnit 4 to 5 migration. The latter will merely drop the dependency, as junit-jupiter is already available as a transitive dependency.