### PR TITLE
Removed update4j

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,11 +299,6 @@ Load and reload configuration such as property files.
 https://github.com/lightbend/config
 https://github.com/arkadius/tsc-reload
 
-## Update4j
-Auto update and launch desktop applications.
-https://github.com/update4j/update4j
-No example yet
-
 ## Vavr
 Functional library.
 https://www.vavr.io/


### PR DESCRIPTION
Remove update4j as it has been archived by the owner

 This repository has been archived by the owner on Mar 18, 2024. It is now read-only.